### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/ruby-fogbugz.gemspec
+++ b/ruby-fogbugz.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = 'A simple Ruby wrapper for the Fogbugz XML API'
   s.license     = 'MIT'
 
-  s.rubyforge_project = 'ruby-fogbugz'
-
   s.add_dependency 'crack', '~> 0.4'
   s.add_dependency 'multipart-post', '~> 2.0'
 


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436